### PR TITLE
Fix reranker top_logprobs error and improve caching (v2.5.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,9 +123,11 @@ SteadyText v1.3.0+ includes document reranking functionality using the Qwen3-Rer
 
 - AIDEV-NOTE: The default reranking model is `Qwen3-Reranker-4B-GGUF`.
 - AIDEV-NOTE: Reranking uses a specific prompt format with system/user/assistant tags.
-- AIDEV-NOTE: Scores are derived from yes/no token probabilities.
+- AIDEV-NOTE: Scores are binary (1.0 for "yes", 0.0 for "no") based on generated token.
+- AIDEV-NOTE: Fixed in v2.4.1 - removed unsupported top_logprobs parameter from model call.
 - AIDEV-TODO: Consider adding support for cross-encoder models.
 - AIDEV-TODO: Add streaming support for large document sets.
+- AIDEV-TODO: Improve scoring to use actual token probabilities instead of binary.
 
 ## Cache Management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "steadytext"
-version = "2.5.1"
+version = "2.5.2"
 description = "Deterministic text generation and embedding with zero configuration"
 readme = "README.md"
 authors = [

--- a/steadytext/__init__.py
+++ b/steadytext/__init__.py
@@ -5,7 +5,8 @@ AIDEV-NOTE: Fixed "Never Fails" - embed() now catches TypeErrors & returns zero 
 """
 
 # Version of the steadytext package - should match pyproject.toml
-__version__ = "2.4.0"
+# AIDEV-NOTE: Always update this when bumping the lib version
+__version__ = "2.5.2"
 
 # Import core functions and classes for public API
 import os


### PR DESCRIPTION
[38;5;238m───────┬────────────────────────────────────────────────────────────────────────[0m
       [38;5;238m│ [0m[1mSTDIN[0m
[38;5;238m───────┼────────────────────────────────────────────────────────────────────────[0m
[38;5;238m   1[0m   [38;5;238m│[0m [38;5;246m## Summary[0m
[38;5;238m   2[0m   [38;5;238m│[0m [38;5;246m- Fixed reranker error: `Llama.__call__() got an unexpected keyword argument 'top_logprobs'`[0m
[38;5;238m   3[0m   [38;5;238m│[0m [38;5;246m- Improved caching to only store successful model results, not fallback scores[0m
[38;5;238m   4[0m   [38;5;238m│[0m [38;5;246m- Bumped version to 2.5.2[0m
[38;5;238m   5[0m   [38;5;238m│[0m 
[38;5;238m   6[0m   [38;5;238m│[0m [38;5;246m## Problem[0m
[38;5;238m   7[0m   [38;5;238m│[0m [38;5;246mThe reranker was failing because it was using `top_logprobs=100` parameter which isn't supported by the direct model call in llama-cpp-python. This caused all reranking operations to fail and fall back to the simple word overlap scoring (often returning 0.0).[0m
[38;5;238m   8[0m   [38;5;238m│[0m 
[38;5;238m   9[0m   [38;5;238m│[0m [38;5;246mAdditionally, these fallback scores were being cached, which meant subsequent requests would return 0.0 even after the underlying issue was fixed.[0m
[38;5;238m  10[0m   [38;5;238m│[0m 
[38;5;238m  11[0m   [38;5;238m│[0m [38;5;246m## Solution[0m
[38;5;238m  12[0m   [38;5;238m│[0m [38;5;246m1. **Removed `top_logprobs` parameter** - Now using only `logprobs=True` which is the correct parameter for the direct model call[0m
[38;5;238m  13[0m   [38;5;238m│[0m [38;5;246m2. **Fixed caching logic** - Added `model_success` flag to track whether the model generated a valid response, and only cache successful results[0m
[38;5;238m  14[0m   [38;5;238m│[0m [38;5;246m3. **Simplified scoring** - Now using binary scoring (1.0 for "yes", 0.0 for "no") based on the generated text[0m
[38;5;238m  15[0m   [38;5;238m│[0m 
[38;5;238m  16[0m   [38;5;238m│[0m [38;5;246m## Test plan[0m
[38;5;238m  17[0m   [38;5;238m│[0m [38;5;246mTested manually with:[0m
[38;5;238m  18[0m   [38;5;238m│[0m [38;5;246m```bash[0m
[38;5;238m  19[0m   [38;5;238m│[0m [38;5;246mecho -e "An apple a day keeps the doctor away\\nPotatoes are root vegetables\\nNurses work in hospitals" | st rerank "It keeps the doctor away"[0m
[38;5;238m  20[0m   [38;5;238m│[0m [38;5;246m```[0m
[38;5;238m  21[0m   [38;5;238m│[0m 
[38;5;238m  22[0m   [38;5;238m│[0m [38;5;246mResults:[0m
[38;5;238m  23[0m   [38;5;238m│[0m [38;5;246m```[0m
[38;5;238m  24[0m   [38;5;238m│[0m [38;5;246m1. [1.0000] An apple a day keeps the doctor away[0m
[38;5;238m  25[0m   [38;5;238m│[0m [38;5;246m2. [0.0000] Potatoes are root vegetables[0m
[38;5;238m  26[0m   [38;5;238m│[0m [38;5;246m3. [0.0000] Nurses work in hospitals[0m
[38;5;238m  27[0m   [38;5;238m│[0m [38;5;246m```[0m
[38;5;238m  28[0m   [38;5;238m│[0m 
[38;5;238m  29[0m   [38;5;238m│[0m [38;5;246mThe reranker now correctly identifies relevant documents.[0m
[38;5;238m  30[0m   [38;5;238m│[0m 
[38;5;238m  31[0m   [38;5;238m│[0m [38;5;246m🤖 Generated with [Claude Code](https://claude.ai/code)[0m
[38;5;238m───────┴────────────────────────────────────────────────────────────────────────[0m