### PR TITLE
feat: add 'unsafe' mode for remote models with seed support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1030,3 +1030,31 @@ SteadyText includes a development container setup for consistent development env
 AIDEV-TODO: Add support for GPU passthrough in devcontainer for CUDA models
 AIDEV-TODO: Consider adding Redis service for distributed cache testing
 AIDEV-NOTE: The devcontainer mounts Docker socket for testing containerized builds
+
+## Unsafe Mode: Remote Models (v2.6.0+)
+
+### AIDEV-NOTE: Remote Model Architecture
+
+SteadyText includes an "unsafe mode" that allows using remote AI models (OpenAI, Cerebras, etc.) with best-effort determinism via seed parameters.
+
+**Key Components:**
+- `providers/base.py` - Base `RemoteModelProvider` class with warning system
+- `providers/openai.py` - OpenAI provider supporting seed-enabled models
+- `providers/cerebras.py` - Cerebras cloud API provider
+- `providers/registry.py` - Provider registry and model routing
+
+**Features:**
+- AIDEV-NOTE: Requires explicit opt-in via `STEADYTEXT_UNSAFE_MODE=true` environment variable
+- AIDEV-NOTE: Shows prominent warnings about best-effort determinism limitations
+- AIDEV-NOTE: Remote models specified as "provider:model" (e.g., "openai:gpt-4o-mini")
+- AIDEV-NOTE: Supports both regular and streaming generation
+- AIDEV-NOTE: Does NOT support structured output, logprobs, or embeddings
+
+**Provider Support:**
+- OpenAI: Models with seed parameter (gpt-4o, gpt-4o-mini, etc.)
+- Cerebras: Llama models via their cloud API
+
+AIDEV-TODO: Add support for more providers (Anthropic when they add seed support, Together.ai, etc.)
+AIDEV-TODO: Consider adding structured output support for remote models
+AIDEV-TODO: Add telemetry to track unsafe mode usage patterns
+AIDEV-NOTE: Remote models are explicitly marked "unsafe" to emphasize they don't provide true determinism

--- a/README.md
+++ b/README.md
@@ -285,6 +285,55 @@ echo "Is Python good?" | st --choices "yes,no,maybe" --wait
 
 ---
 
+## ⚠️ Unsafe Mode: Remote Models (Experimental)
+
+SteadyText now supports remote AI models (OpenAI, Cerebras) with **best-effort determinism** via seed parameters. This feature is explicitly marked as "unsafe" because remote models cannot guarantee reproducibility.
+
+### Why Use Unsafe Mode?
+
+- Access to larger, more capable models
+- Prototype before switching to local models
+- Use when true determinism isn't critical
+
+### Quick Example
+
+```bash
+# Enable unsafe mode
+export STEADYTEXT_UNSAFE_MODE=true
+
+# Use OpenAI
+echo "Explain quantum computing" | st --unsafe-mode --model openai:gpt-4o-mini
+
+# Use Cerebras  
+echo "Write Python code" | st --unsafe-mode --model cerebras:llama3.1-8b
+
+# List available remote models
+st unsafe list-models
+```
+
+### Python API
+
+```python
+import os
+import steadytext
+
+# Enable unsafe mode
+os.environ["STEADYTEXT_UNSAFE_MODE"] = "true"
+
+# Generate with OpenAI (requires OPENAI_API_KEY)
+text = steadytext.generate(
+    "Explain AI", 
+    model="openai:gpt-4o-mini",
+    seed=42  # Best-effort determinism only
+)
+```
+
+⚠️ **WARNING**: Remote models may produce different outputs despite using the same seed. Use local GGUF models for guaranteed determinism.
+
+📚 **[Learn more in the Unsafe Mode Guide](docs/unsafe-mode.md)**
+
+---
+
 ## 📦 Installation & Models
 
 Install stable release:

--- a/docs/unsafe-mode.md
+++ b/docs/unsafe-mode.md
@@ -1,0 +1,187 @@
+# Unsafe Mode: Remote Models with Best-Effort Determinism
+
+> ⚠️ **WARNING**: Remote models provide only **best-effort determinism**. Results may vary between calls, environments, and over time. For true determinism, use local GGUF models (default SteadyText behavior).
+
+## Overview
+
+SteadyText's unsafe mode allows you to use remote AI models (OpenAI, Cerebras, etc.) that support seed parameters for reproducibility. While these models attempt to provide consistent outputs when given the same seed, they cannot guarantee the same level of determinism as local models.
+
+## Why "Unsafe"?
+
+Remote models are considered "unsafe" because:
+
+- **No Guaranteed Determinism**: Results may vary despite using the same seed
+- **External Dependencies**: Relies on third-party APIs that may change
+- **Version Changes**: Model updates can alter outputs
+- **Infrastructure Variability**: Different servers may produce different results
+- **API Costs**: Unlike local models, remote models incur per-token charges
+
+## Enabling Unsafe Mode
+
+Unsafe mode requires explicit opt-in via environment variable:
+
+```bash
+export STEADYTEXT_UNSAFE_MODE=true
+```
+
+## Supported Providers
+
+### OpenAI
+
+Models with seed support:
+- `gpt-4-turbo-preview`
+- `gpt-4-turbo` 
+- `gpt-4o`
+- `gpt-4o-mini`
+- `gpt-3.5-turbo-1106`
+- `gpt-3.5-turbo-0125`
+
+Setup:
+```bash
+export OPENAI_API_KEY=your-api-key
+```
+
+### Cerebras
+
+Models available:
+- `llama3.1-8b`
+- `llama3.1-70b`
+- `llama3-8b`
+- `llama3-70b`
+
+Setup:
+```bash
+export CEREBRAS_API_KEY=your-api-key
+```
+
+## Usage
+
+### Python API
+
+```python
+import os
+import steadytext
+
+# Enable unsafe mode
+os.environ["STEADYTEXT_UNSAFE_MODE"] = "true"
+
+# Use OpenAI
+text = steadytext.generate(
+    "Explain quantum computing",
+    model="openai:gpt-4o-mini",
+    seed=42  # Best-effort determinism
+)
+
+# Use Cerebras
+text = steadytext.generate(
+    "Write a Python function",
+    model="cerebras:llama3.1-8b",
+    seed=42
+)
+
+# Streaming also supported
+for token in steadytext.generate_iter(
+    "Tell me a story",
+    model="openai:gpt-4o-mini"
+):
+    print(token, end='')
+```
+
+### CLI
+
+```bash
+# Enable unsafe mode
+export STEADYTEXT_UNSAFE_MODE=true
+
+# Generate with OpenAI
+echo "Explain AI" | st --unsafe-mode --model openai:gpt-4o-mini
+
+# Generate with Cerebras
+echo "Write code" | st --unsafe-mode --model cerebras:llama3.1-8b
+
+# List available models
+st unsafe list-models
+
+# Check unsafe mode status
+st unsafe status
+```
+
+## Limitations
+
+When using unsafe mode:
+
+1. **No Structured Output**: Remote models don't support `--schema`, `--regex`, or `--choices`
+2. **No Logprobs**: Log probabilities are not available
+3. **No Embeddings**: Only generation is supported, not embeddings
+4. **Best-Effort Only**: Determinism is not guaranteed
+
+## Best Practices
+
+1. **Use for Prototyping**: Test ideas with remote models, then switch to local models for production
+2. **Document Variability**: Note that outputs may change over time
+3. **Set Temperature to 0**: Use `temperature=0` for maximum consistency
+4. **Version Lock**: Document which model versions you're using
+5. **Fallback Planning**: Have a plan for when remote APIs are unavailable
+
+## Warning Messages
+
+When using unsafe mode, you'll see warnings like:
+
+```
+======================================================================
+UNSAFE MODE WARNING: Using OpenAI (gpt-4o-mini) remote model
+======================================================================
+You are using a REMOTE model that provides only BEST-EFFORT determinism.
+Results may vary between:
+  - Different API calls
+  - Different environments
+  - Different times
+  - Provider infrastructure changes
+
+For TRUE determinism, use local GGUF models (default SteadyText behavior).
+======================================================================
+```
+
+## Comparison: Local vs Remote
+
+| Feature | Local Models (Default) | Remote Models (Unsafe) |
+|---------|----------------------|----------------------|
+| Determinism | ✅ Guaranteed | ⚠️ Best-effort only |
+| Cost | ✅ Free after download | ❌ Per-token charges |
+| Speed | ✅ Fast (local) | ❌ Network latency |
+| Privacy | ✅ Fully private | ❌ Data sent to API |
+| Offline | ✅ Works offline | ❌ Requires internet |
+| Models | Limited selection | Many options |
+
+## Troubleshooting
+
+### "Unsafe mode requires STEADYTEXT_UNSAFE_MODE=true"
+
+Set the environment variable:
+```bash
+export STEADYTEXT_UNSAFE_MODE=true
+```
+
+### "Provider not available"
+
+Check your API key:
+```bash
+# OpenAI
+export OPENAI_API_KEY=sk-...
+
+# Cerebras  
+export CEREBRAS_API_KEY=...
+```
+
+### "Model does not support seed parameter"
+
+Use only models listed in the supported models section above.
+
+## Migration Path
+
+1. **Prototype** with remote models for flexibility
+2. **Evaluate** outputs and identify core use cases
+3. **Switch** to local models for production deployment
+4. **Maintain** deterministic outputs over time
+
+Remember: SteadyText's core value is **deterministic** text generation. Use unsafe mode only when you explicitly need remote model capabilities and understand the trade-offs.

--- a/steadytext/cli/commands/__init__.py
+++ b/steadytext/cli/commands/__init__.py
@@ -6,6 +6,7 @@ from .models import models
 from .vector import vector
 from .index import index
 from .completion import completion
+from .unsafe import unsafe
 
 __all__ = [
     "generate",
@@ -16,4 +17,5 @@ __all__ = [
     "vector",
     "index",
     "completion",
+    "unsafe",
 ]

--- a/steadytext/cli/commands/unsafe.py
+++ b/steadytext/cli/commands/unsafe.py
@@ -1,0 +1,98 @@
+"""CLI commands for unsafe mode remote models.
+
+AIDEV-NOTE: These commands help users discover and use remote models
+with best-effort determinism support.
+"""
+
+import click
+import sys
+import os
+
+
+@click.group()
+def unsafe():
+    """Manage unsafe mode for remote models with best-effort determinism."""
+    pass
+
+
+@unsafe.command()
+def list_models():
+    """List available remote models that support seed parameters.
+    
+    WARNING: These models provide only best-effort determinism!
+    """
+    # Check if unsafe mode is enabled
+    if os.environ.get("STEADYTEXT_UNSAFE_MODE", "false").lower() != "true":
+        click.echo(
+            "Note: Unsafe mode is not enabled. Set STEADYTEXT_UNSAFE_MODE=true to use these models.\n",
+            err=True
+        )
+    
+    try:
+        from ...providers.registry import list_remote_models
+        
+        models = list_remote_models()
+        
+        if not models:
+            click.echo("No remote models available.")
+            return
+        
+        click.echo("Available remote models (provider:model format):\n")
+        
+        for provider, model_list in sorted(models.items()):
+            click.echo(f"{provider}:")
+            if model_list:
+                for model in sorted(model_list):
+                    click.echo(f"  - {provider}:{model}")
+            else:
+                click.echo("  (Unable to retrieve model list)")
+            click.echo()
+        
+        click.echo("WARNING: Remote models provide only BEST-EFFORT determinism!")
+        click.echo("Results may vary between calls, environments, and over time.")
+        click.echo("\nFor TRUE determinism, use local GGUF models (default behavior).")
+        
+    except Exception as e:
+        click.echo(f"Error listing models: {e}", err=True)
+        sys.exit(1)
+
+
+@unsafe.command()
+def status():
+    """Check unsafe mode status and configuration."""
+    unsafe_mode = os.environ.get("STEADYTEXT_UNSAFE_MODE", "false").lower() in ["true", "1", "yes"]
+    
+    click.echo(f"Unsafe mode enabled: {'Yes' if unsafe_mode else 'No'}")
+    
+    if unsafe_mode:
+        click.echo("\nWARNING: Unsafe mode is ENABLED!")
+        click.echo("Remote models can be used but provide only best-effort determinism.")
+    else:
+        click.echo("\nTo enable unsafe mode: export STEADYTEXT_UNSAFE_MODE=true")
+    
+    # Check for API keys
+    click.echo("\nAPI key status:")
+    api_keys = {
+        "OpenAI": "OPENAI_API_KEY",
+        "Cerebras": "CEREBRAS_API_KEY",
+    }
+    
+    for provider, env_var in api_keys.items():
+        has_key = bool(os.environ.get(env_var))
+        status = "Set" if has_key else "Not set"
+        click.echo(f"  {provider}: {status} ({env_var})")
+
+
+@unsafe.command()
+def enable():
+    """Show how to enable unsafe mode."""
+    click.echo("To enable unsafe mode for remote models:")
+    click.echo("\nBash/Zsh:")
+    click.echo("  export STEADYTEXT_UNSAFE_MODE=true")
+    click.echo("\nFish:")
+    click.echo("  set -x STEADYTEXT_UNSAFE_MODE true")
+    click.echo("\nWindows CMD:")
+    click.echo("  set STEADYTEXT_UNSAFE_MODE=true")
+    click.echo("\nWindows PowerShell:")
+    click.echo("  $env:STEADYTEXT_UNSAFE_MODE=\"true\"")
+    click.echo("\nWARNING: Remote models provide only best-effort determinism!")

--- a/steadytext/cli/main.py
+++ b/steadytext/cli/main.py
@@ -11,6 +11,7 @@ from .commands.vector import vector
 from .commands.index import index
 from .commands.daemon import daemon
 from .commands.completion import completion
+from .commands.unsafe import unsafe
 
 
 @click.group(invoke_without_command=True)
@@ -107,6 +108,7 @@ cli.add_command(vector)
 cli.add_command(index)
 cli.add_command(daemon)
 cli.add_command(completion)
+cli.add_command(unsafe)
 
 
 def main():

--- a/steadytext/providers/__init__.py
+++ b/steadytext/providers/__init__.py
@@ -1,0 +1,21 @@
+"""Remote model providers for unsafe mode operation.
+
+AIDEV-NOTE: This module provides support for remote AI models (OpenAI, Cerebras, etc.)
+that offer seed parameters for best-effort determinism. These models do NOT guarantee
+the same level of determinism as local GGUF models.
+"""
+
+from .base import RemoteModelProvider, UnsafeModeWarning
+from .openai import OpenAIProvider
+from .cerebras import CerebrasProvider
+from .registry import get_provider, list_providers, is_remote_model
+
+__all__ = [
+    "RemoteModelProvider",
+    "UnsafeModeWarning",
+    "OpenAIProvider", 
+    "CerebrasProvider",
+    "get_provider",
+    "list_providers",
+    "is_remote_model",
+]

--- a/steadytext/providers/cerebras.py
+++ b/steadytext/providers/cerebras.py
@@ -1,0 +1,197 @@
+"""Cerebras provider for unsafe mode.
+
+AIDEV-NOTE: Cerebras provides a seed parameter similar to OpenAI
+for best-effort determinism with their cloud inference API.
+"""
+
+import os
+from typing import Optional, Iterator, Dict, Any, List
+import logging
+import json
+
+from .base import RemoteModelProvider
+
+logger = logging.getLogger("steadytext.providers.cerebras")
+
+# AIDEV-NOTE: Import httpx only when needed
+_httpx_module = None
+
+
+def _get_httpx():
+    """Lazy import of httpx module."""
+    global _httpx_module
+    if _httpx_module is None:
+        try:
+            import httpx
+            _httpx_module = httpx
+        except ImportError:
+            logger.error(
+                "httpx library not installed. Install with: pip install httpx"
+            )
+            return None
+    return _httpx_module
+
+
+class CerebrasProvider(RemoteModelProvider):
+    """Cerebras model provider with seed support.
+    
+    AIDEV-NOTE: Cerebras inference API provides seed parameter for reproducibility.
+    Uses their cloud API at api.cerebras.ai.
+    """
+    
+    # Available models on Cerebras Cloud
+    SUPPORTED_MODELS = [
+        "llama3.1-8b",
+        "llama3.1-70b", 
+        "llama3-8b",
+        "llama3-70b",
+    ]
+    
+    API_BASE = "https://api.cerebras.ai/v1"
+    
+    def __init__(self, api_key: Optional[str] = None, model: str = "llama3.1-8b"):
+        """Initialize Cerebras provider.
+        
+        Args:
+            api_key: Cerebras API key. If None, uses CEREBRAS_API_KEY env var
+            model: Model to use
+        """
+        super().__init__(api_key)
+        self.model = model
+        
+        # Try to get API key from environment if not provided
+        if not self.api_key:
+            self.api_key = os.environ.get("CEREBRAS_API_KEY")
+        
+        self._client = None
+    
+    @property
+    def provider_name(self) -> str:
+        return f"Cerebras ({self.model})"
+    
+    def is_available(self) -> bool:
+        """Check if Cerebras is available."""
+        if not self.api_key:
+            return False
+        
+        httpx = _get_httpx()
+        if httpx is None:
+            return False
+            
+        if self.model not in self.SUPPORTED_MODELS:
+            logger.error(
+                f"Model {self.model} not supported. "
+                f"Supported models: {', '.join(self.SUPPORTED_MODELS)}"
+            )
+            return False
+            
+        return True
+    
+    def _get_client(self):
+        """Get or create httpx client."""
+        if self._client is None:
+            httpx = _get_httpx()
+            if httpx is None:
+                raise RuntimeError("httpx library not available")
+            self._client = httpx.Client(
+                base_url=self.API_BASE,
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                timeout=60.0
+            )
+        return self._client
+    
+    def generate(
+        self,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+        seed: int = 42,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> str:
+        """Generate text using Cerebras with seed for determinism."""
+        self._issue_warning()
+        
+        if not self.is_available():
+            raise RuntimeError("Cerebras provider not available")
+        
+        client = self._get_client()
+        
+        # AIDEV-NOTE: Cerebras uses OpenAI-compatible API format
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_new_tokens or 512,
+            "temperature": temperature,
+            "seed": seed,  # For reproducibility
+            **kwargs
+        }
+        
+        response = client.post("/chat/completions", json=payload)
+        response.raise_for_status()
+        
+        data = response.json()
+        return data["choices"][0]["message"]["content"] or ""
+    
+    def generate_iter(
+        self,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+        seed: int = 42,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> Iterator[str]:
+        """Generate text iteratively using Cerebras streaming."""
+        self._issue_warning()
+        
+        if not self.is_available():
+            raise RuntimeError("Cerebras provider not available")
+        
+        httpx = _get_httpx()
+        if httpx is None:
+            raise RuntimeError("httpx not available")
+        
+        # AIDEV-NOTE: Use streaming with httpx
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_new_tokens or 512,
+            "temperature": temperature,
+            "seed": seed,
+            "stream": True,
+            **kwargs
+        }
+        
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        
+        with httpx.stream(
+            "POST",
+            f"{self.API_BASE}/chat/completions",
+            json=payload,
+            headers=headers,
+            timeout=60.0
+        ) as response:
+            response.raise_for_status()
+            
+            for line in response.iter_lines():
+                if line.startswith("data: "):
+                    data_str = line[6:]  # Remove "data: " prefix
+                    if data_str == "[DONE]":
+                        break
+                    
+                    try:
+                        data = json.loads(data_str)
+                        content = data["choices"][0]["delta"].get("content", "")
+                        if content:
+                            yield content
+                    except json.JSONDecodeError:
+                        logger.warning(f"Failed to parse streaming response: {data_str}")
+    
+    def get_supported_models(self) -> List[str]:
+        """Get list of supported models."""
+        return self.SUPPORTED_MODELS.copy()

--- a/steadytext/providers/openai.py
+++ b/steadytext/providers/openai.py
@@ -1,0 +1,167 @@
+"""OpenAI provider for unsafe mode.
+
+AIDEV-NOTE: OpenAI provides a seed parameter for "best-effort" determinism
+but explicitly states it's not guaranteed across all conditions.
+"""
+
+import os
+from typing import Optional, Iterator, Dict, Any, List, Union
+import logging
+
+from .base import RemoteModelProvider
+
+logger = logging.getLogger("steadytext.providers.openai")
+
+# AIDEV-NOTE: Import OpenAI only when needed to avoid forcing dependency
+_openai_module = None
+
+
+def _get_openai():
+    """Lazy import of openai module."""
+    global _openai_module
+    if _openai_module is None:
+        try:
+            import openai
+            _openai_module = openai
+        except ImportError:
+            logger.error(
+                "OpenAI library not installed. Install with: pip install openai"
+            )
+            return None
+    return _openai_module
+
+
+class OpenAIProvider(RemoteModelProvider):
+    """OpenAI model provider with seed support.
+    
+    AIDEV-NOTE: OpenAI's seed parameter provides best-effort determinism.
+    From their docs: "While we make best efforts to ensure determinism,
+    it is not guaranteed."
+    """
+    
+    # Models that support the seed parameter (as of 2024)
+    SEED_SUPPORTED_MODELS = [
+        "gpt-4-turbo-preview",
+        "gpt-4-1106-preview", 
+        "gpt-4-0125-preview",
+        "gpt-4-turbo",
+        "gpt-4-turbo-2024-04-09",
+        "gpt-4o",
+        "gpt-4o-2024-05-13",
+        "gpt-4o-2024-08-06",
+        "gpt-4o-mini",
+        "gpt-4o-mini-2024-07-18",
+        "gpt-3.5-turbo-1106",
+        "gpt-3.5-turbo-0125",
+    ]
+    
+    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o-mini"):
+        """Initialize OpenAI provider.
+        
+        Args:
+            api_key: OpenAI API key. If None, uses OPENAI_API_KEY env var
+            model: Model to use (must support seed parameter)
+        """
+        super().__init__(api_key)
+        self.model = model
+        
+        # Try to get API key from environment if not provided
+        if not self.api_key:
+            self.api_key = os.environ.get("OPENAI_API_KEY")
+        
+        # Initialize client lazily
+        self._client = None
+    
+    @property
+    def provider_name(self) -> str:
+        return f"OpenAI ({self.model})"
+    
+    def is_available(self) -> bool:
+        """Check if OpenAI is available."""
+        if not self.api_key:
+            return False
+        
+        openai = _get_openai()
+        if openai is None:
+            return False
+            
+        # Check if model supports seed
+        if self.model not in self.SEED_SUPPORTED_MODELS:
+            logger.error(
+                f"Model {self.model} does not support seed parameter. "
+                f"Supported models: {', '.join(self.SEED_SUPPORTED_MODELS)}"
+            )
+            return False
+            
+        return True
+    
+    def _get_client(self):
+        """Get or create OpenAI client."""
+        if self._client is None:
+            openai = _get_openai()
+            if openai is None:
+                raise RuntimeError("OpenAI library not available")
+            self._client = openai.OpenAI(api_key=self.api_key)
+        return self._client
+    
+    def generate(
+        self,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+        seed: int = 42,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> str:
+        """Generate text using OpenAI with seed for best-effort determinism."""
+        self._issue_warning()
+        
+        if not self.is_available():
+            raise RuntimeError("OpenAI provider not available")
+        
+        client = self._get_client()
+        
+        # AIDEV-NOTE: temperature=0 + seed provides maximum determinism possible
+        response = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_new_tokens,
+            temperature=temperature,
+            seed=seed,  # Best-effort determinism
+            **kwargs
+        )
+        
+        return response.choices[0].message.content or ""
+    
+    def generate_iter(
+        self,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+        seed: int = 42,
+        temperature: float = 0.0,
+        **kwargs
+    ) -> Iterator[str]:
+        """Generate text iteratively using OpenAI streaming."""
+        self._issue_warning()
+        
+        if not self.is_available():
+            raise RuntimeError("OpenAI provider not available")
+        
+        client = self._get_client()
+        
+        stream = client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_new_tokens,
+            temperature=temperature,
+            seed=seed,  # Best-effort determinism
+            stream=True,
+            **kwargs
+        )
+        
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                yield chunk.choices[0].delta.content
+    
+    def get_supported_models(self) -> List[str]:
+        """Get list of models that support seed parameter."""
+        return self.SEED_SUPPORTED_MODELS.copy()

--- a/steadytext/providers/registry.py
+++ b/steadytext/providers/registry.py
@@ -1,0 +1,140 @@
+"""Registry for remote model providers.
+
+AIDEV-NOTE: Central registry for managing remote providers and model routing.
+"""
+
+import os
+from typing import Optional, Dict, Type, List
+import logging
+
+from .base import RemoteModelProvider
+from .openai import OpenAIProvider
+from .cerebras import CerebrasProvider
+
+logger = logging.getLogger("steadytext.providers.registry")
+
+# AIDEV-NOTE: Registry of available providers
+PROVIDER_REGISTRY: Dict[str, Type[RemoteModelProvider]] = {
+    "openai": OpenAIProvider,
+    "cerebras": CerebrasProvider,
+}
+
+
+def is_unsafe_mode_enabled() -> bool:
+    """Check if unsafe mode is enabled via environment variable."""
+    return os.environ.get("STEADYTEXT_UNSAFE_MODE", "false").lower() in ["true", "1", "yes"]
+
+
+def is_remote_model(model: Optional[str]) -> bool:
+    """Check if a model string refers to a remote model.
+    
+    Remote models are specified as "provider:model" (e.g., "openai:gpt-4").
+    
+    Args:
+        model: Model string to check
+        
+    Returns:
+        True if model is a remote model specification
+    """
+    if not model:
+        return False
+    
+    # Check if model contains provider prefix
+    if ":" in model:
+        provider_name = model.split(":", 1)[0]
+        return provider_name in PROVIDER_REGISTRY
+    
+    return False
+
+
+def parse_remote_model(model: str) -> tuple[str, str]:
+    """Parse remote model string into provider and model name.
+    
+    Args:
+        model: Model string like "openai:gpt-4o-mini"
+        
+    Returns:
+        Tuple of (provider_name, model_name)
+        
+    Raises:
+        ValueError: If model string is invalid
+    """
+    if ":" not in model:
+        raise ValueError(
+            f"Invalid remote model format: {model}. "
+            f"Expected format: provider:model (e.g., openai:gpt-4o-mini)"
+        )
+    
+    provider_name, model_name = model.split(":", 1)
+    
+    if provider_name not in PROVIDER_REGISTRY:
+        available = ", ".join(PROVIDER_REGISTRY.keys())
+        raise ValueError(
+            f"Unknown provider: {provider_name}. "
+            f"Available providers: {available}"
+        )
+    
+    return provider_name, model_name
+
+
+def get_provider(
+    model: str,
+    api_key: Optional[str] = None
+) -> RemoteModelProvider:
+    """Get a remote model provider instance.
+    
+    Args:
+        model: Model string like "openai:gpt-4o-mini"
+        api_key: Optional API key (uses env vars if not provided)
+        
+    Returns:
+        Configured provider instance
+        
+    Raises:
+        ValueError: If provider not found or model format invalid
+        RuntimeError: If unsafe mode not enabled
+    """
+    if not is_unsafe_mode_enabled():
+        raise RuntimeError(
+            "Remote models require unsafe mode. "
+            "Set STEADYTEXT_UNSAFE_MODE=true to enable. "
+            "WARNING: Remote models provide only best-effort determinism!"
+        )
+    
+    provider_name, model_name = parse_remote_model(model)
+    
+    provider_class = PROVIDER_REGISTRY[provider_name]
+    provider = provider_class(api_key=api_key, model=model_name)
+    
+    if not provider.is_available():
+        raise RuntimeError(
+            f"Provider {provider_name} is not available. "
+            f"Check API key and dependencies."
+        )
+    
+    return provider
+
+
+def list_providers() -> List[str]:
+    """Get list of available provider names."""
+    return list(PROVIDER_REGISTRY.keys())
+
+
+def list_remote_models() -> Dict[str, List[str]]:
+    """Get all available remote models grouped by provider.
+    
+    Returns:
+        Dict mapping provider names to lists of supported models
+    """
+    models = {}
+    
+    for provider_name, provider_class in PROVIDER_REGISTRY.items():
+        try:
+            # Create temporary instance to get model list
+            provider = provider_class()
+            models[provider_name] = provider.get_supported_models()
+        except Exception as e:
+            logger.warning(f"Failed to get models for {provider_name}: {e}")
+            models[provider_name] = []
+    
+    return models

--- a/tests/test_unsafe_mode.py
+++ b/tests/test_unsafe_mode.py
@@ -1,0 +1,272 @@
+"""Tests for unsafe mode remote model providers.
+
+AIDEV-NOTE: These tests verify the unsafe mode functionality without
+actually calling remote APIs (which would be non-deterministic and costly).
+"""
+
+import os
+import pytest
+import warnings
+from unittest.mock import Mock, patch, MagicMock
+
+from steadytext.providers.base import RemoteModelProvider, UnsafeModeWarning
+from steadytext.providers.openai import OpenAIProvider
+from steadytext.providers.cerebras import CerebrasProvider
+from steadytext.providers.registry import (
+    is_remote_model,
+    parse_remote_model,
+    get_provider,
+    is_unsafe_mode_enabled,
+    list_providers,
+)
+
+
+class TestRemoteModelDetection:
+    """Test remote model detection and parsing."""
+    
+    def test_is_remote_model(self):
+        """Test detection of remote model strings."""
+        assert is_remote_model("openai:gpt-4")
+        assert is_remote_model("cerebras:llama3.1-8b")
+        assert not is_remote_model("gemma-3n-2b")
+        assert not is_remote_model("qwen2.5-3b")
+        assert not is_remote_model(None)
+        assert not is_remote_model("")
+        assert not is_remote_model("unknown:model")
+    
+    def test_parse_remote_model(self):
+        """Test parsing of remote model strings."""
+        provider, model = parse_remote_model("openai:gpt-4o-mini")
+        assert provider == "openai"
+        assert model == "gpt-4o-mini"
+        
+        provider, model = parse_remote_model("cerebras:llama3.1-8b")
+        assert provider == "cerebras"
+        assert model == "llama3.1-8b"
+        
+        # Test invalid formats
+        with pytest.raises(ValueError, match="Invalid remote model format"):
+            parse_remote_model("no-colon")
+        
+        with pytest.raises(ValueError, match="Unknown provider"):
+            parse_remote_model("unknown:model")
+
+
+class TestUnsafeModeEnvironment:
+    """Test unsafe mode environment variable handling."""
+    
+    def test_unsafe_mode_disabled_by_default(self, monkeypatch):
+        """Test that unsafe mode is disabled by default."""
+        monkeypatch.delenv("STEADYTEXT_UNSAFE_MODE", raising=False)
+        assert not is_unsafe_mode_enabled()
+    
+    def test_unsafe_mode_enabled(self, monkeypatch):
+        """Test enabling unsafe mode."""
+        for value in ["true", "True", "TRUE", "1", "yes"]:
+            monkeypatch.setenv("STEADYTEXT_UNSAFE_MODE", value)
+            assert is_unsafe_mode_enabled()
+    
+    def test_unsafe_mode_disabled(self, monkeypatch):
+        """Test disabling unsafe mode."""
+        for value in ["false", "False", "FALSE", "0", "no", "anything"]:
+            monkeypatch.setenv("STEADYTEXT_UNSAFE_MODE", value)
+            assert not is_unsafe_mode_enabled()
+
+
+class TestRemoteModelProvider:
+    """Test base RemoteModelProvider functionality."""
+    
+    def test_warning_issued_once(self):
+        """Test that warning is issued only once per provider."""
+        class TestProvider(RemoteModelProvider):
+            @property
+            def provider_name(self):
+                return "TestProvider"
+            
+            def is_available(self):
+                return True
+            
+            def generate(self, prompt, **kwargs):
+                self._issue_warning()
+                return "test"
+            
+            def generate_iter(self, prompt, **kwargs):
+                self._issue_warning()
+                yield "test"
+        
+        provider = TestProvider()
+        
+        # First call should issue warning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            provider.generate("test")
+            assert len(w) == 1
+            assert issubclass(w[0].category, UnsafeModeWarning)
+            assert "UNSAFE MODE WARNING" in str(w[0].message)
+        
+        # Second call should not issue warning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            provider.generate("test again")
+            assert len(w) == 0
+
+
+class TestOpenAIProvider:
+    """Test OpenAI provider (mocked)."""
+    
+    def test_init_with_api_key(self):
+        """Test initialization with API key."""
+        provider = OpenAIProvider(api_key="test-key", model="gpt-4o-mini")
+        assert provider.api_key == "test-key"
+        assert provider.model == "gpt-4o-mini"
+    
+    def test_init_from_env(self, monkeypatch):
+        """Test initialization from environment."""
+        monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+        provider = OpenAIProvider(model="gpt-4o-mini")
+        assert provider.api_key == "env-key"
+    
+    def test_is_available_no_key(self):
+        """Test availability check without API key."""
+        provider = OpenAIProvider(api_key=None)
+        assert not provider.is_available()
+    
+    def test_is_available_unsupported_model(self):
+        """Test availability with unsupported model."""
+        provider = OpenAIProvider(api_key="test", model="gpt-3.5-turbo")
+        assert not provider.is_available()
+    
+    def test_supported_models(self):
+        """Test getting supported models."""
+        provider = OpenAIProvider()
+        models = provider.get_supported_models()
+        assert "gpt-4o-mini" in models
+        assert "gpt-4o" in models
+        assert isinstance(models, list)
+    
+    @patch("steadytext.providers.openai._get_openai")
+    def test_generate_mock(self, mock_get_openai, monkeypatch):
+        """Test generation with mocked OpenAI."""
+        monkeypatch.setenv("STEADYTEXT_UNSAFE_MODE", "true")
+        
+        # Mock OpenAI module and client
+        mock_openai = Mock()
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.choices = [Mock(message=Mock(content="Generated text"))]
+        
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.OpenAI.return_value = mock_client
+        mock_get_openai.return_value = mock_openai
+        
+        provider = OpenAIProvider(api_key="test", model="gpt-4o-mini")
+        
+        # Should issue warning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = provider.generate("Test prompt", seed=42)
+            assert len(w) == 1
+            assert issubclass(w[0].category, UnsafeModeWarning)
+        
+        assert result == "Generated text"
+        
+        # Verify API call
+        mock_client.chat.completions.create.assert_called_once()
+        call_args = mock_client.chat.completions.create.call_args
+        assert call_args.kwargs["model"] == "gpt-4o-mini"
+        assert call_args.kwargs["seed"] == 42
+        assert call_args.kwargs["temperature"] == 0.0
+
+
+class TestCerebrasProvider:
+    """Test Cerebras provider (mocked)."""
+    
+    def test_init_with_api_key(self):
+        """Test initialization with API key."""
+        provider = CerebrasProvider(api_key="test-key", model="llama3.1-8b")
+        assert provider.api_key == "test-key"
+        assert provider.model == "llama3.1-8b"
+    
+    def test_init_from_env(self, monkeypatch):
+        """Test initialization from environment."""
+        monkeypatch.setenv("CEREBRAS_API_KEY", "env-key")
+        provider = CerebrasProvider(model="llama3.1-8b")
+        assert provider.api_key == "env-key"
+    
+    def test_supported_models(self):
+        """Test getting supported models."""
+        provider = CerebrasProvider()
+        models = provider.get_supported_models()
+        assert "llama3.1-8b" in models
+        assert "llama3.1-70b" in models
+        assert isinstance(models, list)
+
+
+class TestProviderRegistry:
+    """Test provider registry functionality."""
+    
+    def test_list_providers(self):
+        """Test listing available providers."""
+        providers = list_providers()
+        assert "openai" in providers
+        assert "cerebras" in providers
+        assert len(providers) >= 2
+    
+    def test_get_provider_unsafe_mode_required(self, monkeypatch):
+        """Test that get_provider requires unsafe mode."""
+        monkeypatch.delenv("STEADYTEXT_UNSAFE_MODE", raising=False)
+        
+        with pytest.raises(RuntimeError, match="Remote models require unsafe mode"):
+            get_provider("openai:gpt-4")
+    
+    @patch("steadytext.providers.openai.OpenAIProvider.is_available")
+    def test_get_provider_not_available(self, mock_is_available, monkeypatch):
+        """Test error when provider not available."""
+        monkeypatch.setenv("STEADYTEXT_UNSAFE_MODE", "true")
+        mock_is_available.return_value = False
+        
+        with pytest.raises(RuntimeError, match="Provider openai is not available"):
+            get_provider("openai:gpt-4")
+
+
+class TestIntegration:
+    """Test integration with main generate function."""
+    
+    @patch("steadytext.providers.openai._get_openai")
+    def test_generate_with_remote_model(self, mock_get_openai, monkeypatch):
+        """Test generate function with remote model."""
+        monkeypatch.setenv("STEADYTEXT_UNSAFE_MODE", "true")
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        
+        # Mock OpenAI
+        mock_openai = Mock()
+        mock_client = Mock()
+        mock_response = Mock()
+        mock_response.choices = [Mock(message=Mock(content="Remote generated text"))]
+        
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.OpenAI.return_value = mock_client
+        mock_get_openai.return_value = mock_openai
+        
+        # Import here to ensure environment is set
+        from steadytext import generate
+        
+        result = generate("Test prompt", model="openai:gpt-4o-mini")
+        assert result == "Remote generated text"
+    
+    def test_generate_without_unsafe_mode(self, monkeypatch):
+        """Test that remote models fail without unsafe mode."""
+        monkeypatch.delenv("STEADYTEXT_UNSAFE_MODE", raising=False)
+        
+        from steadytext import generate
+        
+        result = generate("Test prompt", model="openai:gpt-4")
+        assert result is None  # Should fail and return None
+
+
+# AIDEV-NOTE: Additional tests could be added for:
+# - Streaming generation with remote models
+# - Error handling for API failures
+# - Structured output rejection with remote models
+# - CLI command testing
+# However, these would require more complex mocking


### PR DESCRIPTION
Closes #71

This PR implements an "unsafe" mode in the steadytext Python library that allows users to use remote models (OpenAI, Cerebras, etc.) that offer a `seed` parameter for best-effort determinism.

## Changes

- Added `providers` module with base class and implementations for OpenAI and Cerebras
- Modified core generator to support remote models via "provider:model" format
- Added CLI support with `--unsafe-mode` flag and new `st unsafe` command group
- Requires `STEADYTEXT_UNSAFE_MODE=true` environment variable for safety
- Shows prominent warnings about best-effort determinism limitations
- Added comprehensive documentation and tests

## Important Notes

Remote models are explicitly marked as "unsafe" because they:
- Cannot guarantee deterministic outputs despite seed parameters
- May produce different results across environments and time
- Depend on external APIs that may change

For true determinism, users should continue using local GGUF models (default behavior).

Generated with [Claude Code](https://claude.ai/code)