### PR TITLE
feat: add -h as alias for --help to all CLI subcommands

### DIFF
--- a/steadytext/cli/commands/cache.py
+++ b/steadytext/cli/commands/cache.py
@@ -15,14 +15,14 @@ def cache():
     pass
 
 
-@cache.command()
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
 def path():
     """Show the cache directory path."""
     cache_dir = get_cache_dir() / "caches"
     click.echo(str(cache_dir))
 
 
-@cache.command()
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
 def status():
     """Show cache status."""
     cache_manager = get_cache_manager()
@@ -44,7 +44,7 @@ def status():
     click.echo(f"  Capacity: {embed_stats.get('capacity', 0)}")
 
 
-@cache.command()
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
 def stats():
     """Show cache statistics."""
     cache_dir = get_cache_dir() / "caches"
@@ -78,7 +78,7 @@ def stats():
     click.echo(json.dumps(stats_data, indent=2))
 
 
-@cache.command()
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--generation", is_flag=True, help="Clear only generation cache")
 @click.option("--embedding", is_flag=True, help="Clear only embedding cache")
 @click.confirmation_option(prompt="Are you sure you want to clear the cache(s)?")
@@ -116,7 +116,7 @@ def clear(generation: bool, embedding: bool):
         click.echo("No caches were cleared")
 
 
-@cache.command()
+@cache.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("output_file", type=click.Path())
 def export(output_file: str):
     """Export cache to file."""

--- a/steadytext/cli/commands/completion.py
+++ b/steadytext/cli/commands/completion.py
@@ -115,7 +115,7 @@ Alternative (for current session only):
     return instructions
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--shell",
     type=click.Choice(["bash", "zsh", "fish"]),

--- a/steadytext/cli/commands/daemon.py
+++ b/steadytext/cli/commands/daemon.py
@@ -49,7 +49,7 @@ def daemon():
     pass
 
 
-@daemon.command()
+@daemon.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--host", default=DEFAULT_DAEMON_HOST, help="Host to bind to")
 @click.option("--port", type=int, default=DEFAULT_DAEMON_PORT, help="Port to bind to")
 @click.option(
@@ -150,7 +150,7 @@ def start(
             sys.exit(1)
 
 
-@daemon.command()
+@daemon.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--force", is_flag=True, help="Force kill the daemon process")
 def stop(force: bool):
     """Stop the SteadyText daemon server."""
@@ -191,7 +191,7 @@ def stop(force: bool):
         sys.exit(1)
 
 
-@daemon.command()
+@daemon.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--json", "output_json", is_flag=True, help="Output status as JSON")
 def status(output_json: bool):
     """Check the status of the SteadyText daemon."""
@@ -232,7 +232,7 @@ def status(output_json: bool):
         click.echo(f"Responsive: {'Yes' if status_info['responsive'] else 'No'}")
 
 
-@daemon.command()
+@daemon.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--host", default=DEFAULT_DAEMON_HOST, help="Host to bind to")
 @click.option("--port", type=int, default=DEFAULT_DAEMON_PORT, help="Port to bind to")
 @click.option("--no-preload", is_flag=True, help="Don't preload models on startup")

--- a/steadytext/cli/commands/embed.py
+++ b/steadytext/cli/commands/embed.py
@@ -5,7 +5,7 @@ import numpy as np
 
 # AIDEV-NOTE: Fixed CLI consistency issue (2025-06-28) - Changed from single --format option
 # to individual flags (--json, --numpy, --hex) to match generate command pattern
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("text", nargs=-1)
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 @click.option("--numpy", "output_numpy", is_flag=True, help="Output as numpy array")

--- a/steadytext/cli/commands/generate.py
+++ b/steadytext/cli/commands/generate.py
@@ -8,7 +8,7 @@ from ... import generate as steady_generate, generate_iter as steady_generate_it
 from .index import search_index_for_context, get_default_index_path
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("prompt", default="-", required=False)
 @click.option(
     "--raw",

--- a/steadytext/cli/commands/index.py
+++ b/steadytext/cli/commands/index.py
@@ -146,7 +146,7 @@ def index():
     pass
 
 
-@index.command()
+@index.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("input_files", nargs=-1, required=True, type=click.Path(exists=True))
 @click.option("--output", "-o", default="default.faiss", help="Output index filename")
 @click.option("--chunk-size", default=512, help="Maximum tokens per chunk")
@@ -267,7 +267,7 @@ def create(
     click.echo(f"  Dimension: {dimension}")
 
 
-@index.command()
+@index.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("index_file", type=click.Path(exists=True))
 def info(index_file: str):
     """Show information about a FAISS index.
@@ -312,7 +312,7 @@ def info(index_file: str):
         click.echo(f"    Size: {file_info['size']:,} bytes")
 
 
-@index.command()
+@index.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("index_file", type=click.Path(exists=True))
 @click.argument("query")
 @click.option("--top-k", "-k", default=3, help="Number of results to return")

--- a/steadytext/cli/commands/models.py
+++ b/steadytext/cli/commands/models.py
@@ -37,7 +37,7 @@ def models():
     pass
 
 
-@models.command("list")
+@models.command("list", context_settings={"help_option_names": ["-h", "--help"]})
 def list_models():
     """Check model download status."""
     model_dir = get_cache_dir()
@@ -79,7 +79,7 @@ def list_models():
     click.echo(json.dumps(status_data, indent=2))
 
 
-@models.command()
+@models.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--size",
     type=click.Choice(["small", "large"]),
@@ -186,13 +186,13 @@ def download(size: Optional[str], model: Optional[str], all: bool):
             click.echo(f" ✗ Failed: {e}")
 
 
-@models.command()
+@models.command(context_settings={"help_option_names": ["-h", "--help"]})
 def path():
     """Show model cache directory."""
     click.echo(str(get_cache_dir()))
 
 
-@models.command()
+@models.command(context_settings={"help_option_names": ["-h", "--help"]})
 def list():
     """List available models."""
     # Show size shortcuts
@@ -212,7 +212,7 @@ def list():
             )
 
 
-@models.command()
+@models.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--size", type=click.Choice(["small", "large"]), help="Model size to preload"
 )
@@ -263,7 +263,7 @@ def preload(ctx, size: Optional[str]):
         click.echo(f"\nError preloading models: {e}", err=True)
 
 
-@models.command()
+@models.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--size",
     type=click.Choice(["small", "large"]),

--- a/steadytext/cli/commands/rerank.py
+++ b/steadytext/cli/commands/rerank.py
@@ -6,7 +6,7 @@ from typing import List
 
 # AIDEV-NOTE: CLI command for reranking documents based on query relevance
 # Uses the Qwen3-Reranker model to score query-document pairs
-@click.command()
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("query")
 @click.argument("documents", nargs=-1)
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")

--- a/steadytext/cli/commands/vector.py
+++ b/steadytext/cli/commands/vector.py
@@ -38,7 +38,7 @@ def _manhattan_distance(vec1: np.ndarray, vec2: np.ndarray) -> float:
     return float(np.sum(np.abs(vec1 - vec2)))
 
 
-@vector.command()
+@vector.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("text1")
 @click.argument("text2")
 @click.option(
@@ -84,7 +84,7 @@ def similarity(text1: str, text2: str, metric: str, output_json: bool, seed: int
         click.echo(f"{score:.6f}")
 
 
-@vector.command()
+@vector.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("text1")
 @click.argument("text2")
 @click.option(
@@ -131,7 +131,7 @@ def distance(text1: str, text2: str, metric: str, output_json: bool, seed: int):
         click.echo(f"{dist:.6f}")
 
 
-@vector.command()
+@vector.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("query")
 @click.option(
     "--candidates",
@@ -238,7 +238,7 @@ def search(
             click.echo(f"{text}\t{score:.6f}")
 
 
-@vector.command()
+@vector.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("texts", nargs=-1, required=True)
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 @click.option(
@@ -282,7 +282,7 @@ def average(texts: Tuple[str, ...], output_json: bool, seed: int):
         click.echo(np.array2string(avg_embedding[:50], separator=", "))
 
 
-@vector.command()
+@vector.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("base")
 @click.argument("add_terms", nargs=-1)
 @click.option("--subtract", multiple=True, help="Terms to subtract from the result")

--- a/steadytext/cli/main.py
+++ b/steadytext/cli/main.py
@@ -13,7 +13,10 @@ from .commands.daemon import daemon
 from .commands.completion import completion
 
 
-@click.group(invoke_without_command=True)
+@click.group(
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.pass_context
 @click.option("--version", is_flag=True, help="Show version")
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,3 +187,180 @@ class TestModelsCli:
         )
         assert result.exit_code == 0
         assert "Preloading models... (skipped in test environment)" in result.output
+
+
+class TestHelpOptionAlias:
+    """Test suite for -h as an alias for --help across all commands."""
+
+    def test_main_help_short(self, runner):
+        """Test `st -h` shows help."""
+        result = runner.invoke(cli, ["-h"])
+        assert result.exit_code == 0
+        assert "SteadyText: Deterministic text generation" in result.output
+        assert "Commands:" in result.output
+
+    def test_main_help_long(self, runner):
+        """Test `st --help` shows help."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "SteadyText: Deterministic text generation" in result.output
+        assert "Commands:" in result.output
+
+    def test_generate_help_short(self, runner):
+        """Test `st generate -h` shows help."""
+        result = runner.invoke(cli, ["generate", "-h"])
+        assert result.exit_code == 0
+        assert "Generate text from a prompt" in result.output
+        assert "Examples:" in result.output
+
+    def test_generate_help_long(self, runner):
+        """Test `st generate --help` shows help."""
+        result = runner.invoke(cli, ["generate", "--help"])
+        assert result.exit_code == 0
+        assert "Generate text from a prompt" in result.output
+        assert "Examples:" in result.output
+
+    def test_embed_help_short(self, runner):
+        """Test `st embed -h` shows help."""
+        result = runner.invoke(cli, ["embed", "-h"])
+        assert result.exit_code == 0
+        assert "Generate embedding vector for text" in result.output
+
+    def test_embed_help_long(self, runner):
+        """Test `st embed --help` shows help."""
+        result = runner.invoke(cli, ["embed", "--help"])
+        assert result.exit_code == 0
+        assert "Generate embedding vector for text" in result.output
+
+    def test_rerank_help_short(self, runner):
+        """Test `st rerank -h` shows help."""
+        result = runner.invoke(cli, ["rerank", "-h"])
+        assert result.exit_code == 0
+        assert "Rerank documents by relevance to a query" in result.output
+
+    def test_rerank_help_long(self, runner):
+        """Test `st rerank --help` shows help."""
+        result = runner.invoke(cli, ["rerank", "--help"])
+        assert result.exit_code == 0
+        assert "Rerank documents by relevance to a query" in result.output
+
+    def test_cache_help_short(self, runner):
+        """Test `st cache -h` shows help."""
+        result = runner.invoke(cli, ["cache", "-h"])
+        assert result.exit_code == 0
+        assert "Manage SteadyText cache" in result.output
+        assert "Commands:" in result.output
+
+    def test_cache_help_long(self, runner):
+        """Test `st cache --help` shows help."""
+        result = runner.invoke(cli, ["cache", "--help"])
+        assert result.exit_code == 0
+        assert "Manage SteadyText cache" in result.output
+        assert "Commands:" in result.output
+
+    def test_cache_subcommand_help_short(self, runner):
+        """Test `st cache path -h` shows help."""
+        result = runner.invoke(cli, ["cache", "path", "-h"])
+        assert result.exit_code == 0
+        assert "Show the cache directory path" in result.output
+
+    def test_models_help_short(self, runner):
+        """Test `st models -h` shows help."""
+        result = runner.invoke(cli, ["models", "-h"])
+        assert result.exit_code == 0
+        assert "Manage SteadyText models" in result.output
+        assert "Commands:" in result.output
+
+    def test_models_help_long(self, runner):
+        """Test `st models --help` shows help."""
+        result = runner.invoke(cli, ["models", "--help"])
+        assert result.exit_code == 0
+        assert "Manage SteadyText models" in result.output
+        assert "Commands:" in result.output
+
+    def test_models_subcommand_help_short(self, runner):
+        """Test `st models list -h` shows help."""
+        result = runner.invoke(cli, ["models", "list", "-h"])
+        assert result.exit_code == 0
+        assert "List available models" in result.output
+
+    def test_vector_help_short(self, runner):
+        """Test `st vector -h` shows help."""
+        result = runner.invoke(cli, ["vector", "-h"])
+        assert result.exit_code == 0
+        assert "Perform vector operations on embeddings" in result.output
+        assert "Commands:" in result.output
+
+    def test_vector_help_long(self, runner):
+        """Test `st vector --help` shows help."""
+        result = runner.invoke(cli, ["vector", "--help"])
+        assert result.exit_code == 0
+        assert "Perform vector operations on embeddings" in result.output
+        assert "Commands:" in result.output
+
+    def test_index_help_short(self, runner):
+        """Test `st index -h` shows help."""
+        result = runner.invoke(cli, ["index", "-h"])
+        assert result.exit_code == 0
+        assert "Manage FAISS indices for vector search" in result.output
+        assert "Commands:" in result.output
+
+    def test_index_help_long(self, runner):
+        """Test `st index --help` shows help."""
+        result = runner.invoke(cli, ["index", "--help"])
+        assert result.exit_code == 0
+        assert "Manage FAISS indices for vector search" in result.output
+        assert "Commands:" in result.output
+
+    def test_daemon_help_short(self, runner):
+        """Test `st daemon -h` shows help."""
+        result = runner.invoke(cli, ["daemon", "-h"])
+        assert result.exit_code == 0
+        assert "Manage the SteadyText daemon server" in result.output
+        assert "Commands:" in result.output
+
+    def test_daemon_help_long(self, runner):
+        """Test `st daemon --help` shows help."""
+        result = runner.invoke(cli, ["daemon", "--help"])
+        assert result.exit_code == 0
+        assert "Manage the SteadyText daemon server" in result.output
+        assert "Commands:" in result.output
+
+    def test_completion_help_short(self, runner):
+        """Test `st completion -h` shows help."""
+        result = runner.invoke(cli, ["completion", "-h"])
+        assert result.exit_code == 0
+        assert "Generate shell completion script" in result.output
+
+    def test_completion_help_long(self, runner):
+        """Test `st completion --help` shows help."""
+        result = runner.invoke(cli, ["completion", "--help"])
+        assert result.exit_code == 0
+        assert "Generate shell completion script" in result.output
+
+    # AIDEV-NOTE: Test that -h and --help produce identical output
+    def test_help_output_identical(self, runner):
+        """Test that -h and --help produce identical output for all commands."""
+        # Test main command
+        result_h = runner.invoke(cli, ["-h"])
+        result_help = runner.invoke(cli, ["--help"])
+        assert result_h.output == result_help.output
+
+        # Test each subcommand
+        subcommands = [
+            "generate",
+            "embed",
+            "rerank",
+            "cache",
+            "models",
+            "vector",
+            "index",
+            "daemon",
+            "completion",
+        ]
+        for cmd in subcommands:
+            result_h = runner.invoke(cli, [cmd, "-h"])
+            result_help = runner.invoke(cli, [cmd, "--help"])
+            assert result_h.output == result_help.output, (
+                f"Help output differs for '{cmd}' command"
+            )


### PR DESCRIPTION
### **User description**
This PR implements the requested feature to add `-h` as an alias for `--help` across all CLI subcommands.

## Changes

- Added `context_settings={"help_option_names": ["-h", "--help"]}` to all @click.command() decorators
- Updated main CLI group and all 9 subcommands
- Added comprehensive test suite to verify -h functionality

## Testing

All tests pass. The new test class `TestHelpOptionAlias` verifies:
- Both `-h` and `--help` work for all commands
- They produce identical output
- Nested subcommands also support the alias

Fixes #83

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `-h` as alias for `--help` across all CLI commands

- Update main CLI group and all 9 subcommands

- Add comprehensive test suite for help option functionality

- Ensure identical output for both `-h` and `--help` flags


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Commands"] --> B["Add context_settings"]
  B --> C["Support -h and --help"]
  C --> D["Test Coverage"]
  D --> E["Verify Identical Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>cache.py</strong><dd><code>Add -h help alias to cache subcommands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-98a3c4547c11258115a1b758cab3ba6ab6d4e5dcd5eac8fcc4ec82d5d80efe13">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>completion.py</strong><dd><code>Add -h help alias to completion command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-ccd1190efd649e9ea62be1a7e8b5dd66ce262277ac917fd8e4fc1b337d73857a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>daemon.py</strong><dd><code>Add -h help alias to daemon subcommands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-dce3b5b87cf5254fa2a152c01f4f289bcf06f37839ac8fbde454700353785222">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>embed.py</strong><dd><code>Add -h help alias to embed command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-9d9f433ec431306037230074e596fdfdbc57f52371bcece4b4c8062c210187b7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate.py</strong><dd><code>Add -h help alias to generate command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-663fd5ad33486d094cc3e26b178caf3bfd09f7a4bc2040e9daedf5de05362c3f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.py</strong><dd><code>Add -h help alias to index subcommands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-4380f9edf0cfd7d59c66eb51b853d04a8be7c63c699323e670d0867eaceb4ae2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>models.py</strong><dd><code>Add -h help alias to models subcommands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-f0a3978296e118c695b123d96143f6f206fe4f7d3e9064efbde7d9d4ea7b914b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rerank.py</strong><dd><code>Add -h help alias to rerank command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-9159f72759006b4dd3301d510ee706f5428b57c25e3bfe869b45d61714c58195">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vector.py</strong><dd><code>Add -h help alias to vector subcommands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-e38e76d8362322a209b459527dc6c77561a02d0fef7edf835c94bff769b04662">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Add -h help alias to main CLI group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-101ae9340b2705178c4548244cef0f83b4863a9dd1eab7ae07a8c40b0d889f48">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_cli.py</strong><dd><code>Add comprehensive tests for -h help functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/86/files#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032e">+177/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `-h` as an alias for `--help` to all CLI subcommands and implement tests to ensure functionality and consistency.
> 
>   - **Behavior**:
>     - Add `-h` as an alias for `--help` in all CLI subcommands by updating `@click.command()` decorators with `context_settings={"help_option_names": ["-h", "--help"]}`.
>     - Affects main CLI group in `main.py` and all 9 subcommands including `cache.py`, `completion.py`, and `daemon.py`.
>   - **Testing**:
>     - New test class `TestHelpOptionAlias` in `test_cli.py` verifies `-h` and `--help` work for all commands and produce identical output.
>     - Tests cover main command and all subcommands, ensuring comprehensive coverage.
>   - **Misc**:
>     - Fixes issue #83.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fsteadytext&utm_source=github&utm_medium=referral)<sup> for 03b089ae1d73e03e586bbebe20ca3d1e5f0dfe9b. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->