### PR TITLE
fix: add schema qualification to all table references in pg_steadytext SQL files

### DIFF
--- a/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
@@ -362,9 +362,9 @@ import zmq
 try:
     # Get daemon configuration - FIXED: Use schema-qualified table name
     # Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
     host_rv = plpy.execute(plan, ["daemon_host"])
     port_rv = plpy.execute(plan, ["daemon_port"])
     

--- a/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
@@ -41,8 +41,10 @@ daemon_connector = GD.get('module_daemon_connector')
 if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
-# Get configuration - FIXED: Use schema-qualified table name
-plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+# Get configuration - FIXED: Get schema dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens, using the provided value or fetching the default
 resolved_max_tokens = max_tokens
@@ -83,9 +85,9 @@ if use_cache:
     else:
         cache_key = f"{prompt}::EOS::{eos_string}"
     
-    # Try to get from cache first - FIXED: Use schema-qualified table name
-    cache_plan = plpy.prepare("""
-        UPDATE @extschema@.steadytext_cache 
+    # Try to get from cache first - FIXED: Get schema dynamically at runtime
+    cache_plan = plpy.prepare(f"""
+        UPDATE {plpy.quote_ident(current_schema)}.steadytext_cache 
         SET access_count = access_count + 1,
             last_accessed = NOW()
         WHERE cache_key = $1
@@ -122,8 +124,8 @@ try:
     
     # Store in cache if successful and caching is enabled - FIXED: Use schema-qualified table name
     if use_cache:
-        insert_plan = plpy.prepare("""
-            INSERT INTO @extschema@.steadytext_cache (cache_key, response)
+        insert_plan = plpy.prepare(f"""
+            INSERT INTO {plpy.quote_ident(current_schema)}.steadytext_cache (cache_key, response)
             VALUES ($1, $2)
             ON CONFLICT (cache_key) DO UPDATE
             SET response = EXCLUDED.response,
@@ -253,9 +255,9 @@ if use_cache:
     # Include mode in cache key for Jina v4 compatibility
     cache_key = f"embed:{mode}:{text}"
     
-    # Try to get from cache first - FIXED: Use schema-qualified table name
-    cache_plan = plpy.prepare("""
-        UPDATE @extschema@.steadytext_embedding_cache 
+    # Try to get from cache first - FIXED: Get schema dynamically at runtime
+    cache_plan = plpy.prepare(f"""
+        UPDATE {plpy.quote_ident(current_schema)}.steadytext_embedding_cache 
         SET access_count = access_count + 1,
             last_accessed = NOW()
         WHERE cache_key = $1
@@ -268,7 +270,10 @@ if use_cache:
         return cache_result[0]["embedding"]
 
 # Cache miss - generate new embedding - FIXED: Use schema-qualified table name
-plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+# Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 host_rv = plpy.execute(plan, ["daemon_host"])
 port_rv = plpy.execute(plan, ["daemon_port"])
@@ -289,12 +294,12 @@ try:
     
     # Store in cache if successful and caching is enabled - FIXED: Use schema-qualified table name
     if use_cache:
-        insert_plan = plpy.prepare("""
-            INSERT INTO @extschema@.steadytext_embedding_cache (cache_key, embedding)
+        insert_plan = plpy.prepare(f"""
+            INSERT INTO {plpy.quote_ident(current_schema)}.steadytext_embedding_cache (cache_key, embedding)
             VALUES ($1, $2)
             ON CONFLICT (cache_key) DO UPDATE
             SET embedding = EXCLUDED.embedding,
-                access_count = @extschema@.steadytext_embedding_cache.access_count + 1,
+                access_count = steadytext_embedding_cache.access_count + 1,
                 last_accessed = NOW()
         """, ["text", "vector"])
         plpy.execute(insert_plan, [cache_key, result])
@@ -356,7 +361,10 @@ import zmq
 
 try:
     # Get daemon configuration - FIXED: Use schema-qualified table name
-    plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
     host_rv = plpy.execute(plan, ["daemon_host"])
     port_rv = plpy.execute(plan, ["daemon_port"])
     
@@ -381,8 +389,8 @@ try:
         
         # Update health table if we got a successful response - FIXED: Use schema-qualified table name
         if response.get("status") == "ok":
-            update_plan = plpy.prepare("""
-                INSERT INTO @extschema@.steadytext_daemon_health (
+            update_plan = plpy.prepare(f"""
+                INSERT INTO {plpy.quote_ident(current_schema)}.steadytext_daemon_health (
                     daemon_id, endpoint, last_heartbeat, status, version, models_loaded
                 ) VALUES (
                     'default', $1, NOW(), 'healthy', $2, $3
@@ -406,9 +414,9 @@ try:
         context.term()
         
 except Exception as e:
-    # Update health table to reflect unhealthy status - FIXED: Use schema-qualified table name
-    update_plan = plpy.prepare("""
-        UPDATE @extschema@.steadytext_daemon_health 
+    # Update health table to reflect unhealthy status - FIXED: Get schema dynamically at runtime
+    update_plan = plpy.prepare(f"""
+        UPDATE {plpy.quote_ident(current_schema)}.steadytext_daemon_health 
         SET status = 'unhealthy', last_heartbeat = NOW()
         WHERE daemon_id = 'default'
     """)
@@ -435,7 +443,10 @@ import time
 
 try:
     # Get configuration - FIXED: Use schema-qualified table name
-    plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
     
     # Use provided values or defaults from config
     if host is None:
@@ -446,9 +457,9 @@ try:
         port_rv = plpy.execute(plan, ["daemon_port"])
         port = json.loads(port_rv[0]["value"]) if port_rv else 5555
     
-    # Update daemon health status - FIXED: Use schema-qualified table name
-    update_plan = plpy.prepare("""
-        INSERT INTO @extschema@.steadytext_daemon_health (daemon_id, endpoint, status)
+    # Update daemon health status - FIXED: Get schema dynamically at runtime
+    update_plan = plpy.prepare(f"""
+        INSERT INTO {plpy.quote_ident(current_schema)}.steadytext_daemon_health (daemon_id, endpoint, status)
         VALUES ('default', $1, 'starting')
         ON CONFLICT (daemon_id) DO UPDATE SET
             endpoint = EXCLUDED.endpoint,
@@ -535,9 +546,9 @@ if use_cache:
     # Create cache key from query, document, and task
     cache_key = f"rerank:{task_description}:{query}:{document}"
     
-    # Try to get from cache first - FIXED: Use schema-qualified table name
-    cache_plan = plpy.prepare("""
-        UPDATE @extschema@.steadytext_rerank_cache 
+    # Try to get from cache first - FIXED: Get schema dynamically at runtime
+    cache_plan = plpy.prepare(f"""
+        UPDATE {plpy.quote_ident(current_schema)}.steadytext_rerank_cache 
         SET access_count = access_count + 1,
             last_accessed = NOW()
         WHERE cache_key = $1
@@ -550,7 +561,10 @@ if use_cache:
         return cache_result[0]["score"]
 
 # Cache miss - compute new score - FIXED: Use schema-qualified table name
-plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+# Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 host_rv = plpy.execute(plan, ["daemon_host"])
 port_rv = plpy.execute(plan, ["daemon_port"])
@@ -570,12 +584,12 @@ try:
     
     # Store in cache if successful and caching is enabled - FIXED: Use schema-qualified table name
     if use_cache:
-        insert_plan = plpy.prepare("""
-            INSERT INTO @extschema@.steadytext_rerank_cache (cache_key, score, query_text, document_text)
+        insert_plan = plpy.prepare(f"""
+            INSERT INTO {plpy.quote_ident(current_schema)}.steadytext_rerank_cache (cache_key, score, query_text, document_text)
             VALUES ($1, $2, $3, $4)
             ON CONFLICT (cache_key) DO UPDATE
             SET score = EXCLUDED.score,
-                access_count = @extschema@.steadytext_rerank_cache.access_count + 1,
+                access_count = steadytext_rerank_cache.access_count + 1,
                 last_accessed = NOW()
         """, ["text", "float8", "text", "text"])
         plpy.execute(insert_plan, [cache_key, result, query, document])
@@ -846,8 +860,10 @@ AS $c$
         return json.dumps(state_data)
 
     # Extract facts from the value
-    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
-    plan = plpy.prepare("SELECT @extschema@.steadytext_extract_facts($1, 3) as facts", ["text"])
+    # AIDEV-NOTE: Get schema dynamically at runtime for TimescaleDB continuous aggregates compatibility
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT {plpy.quote_ident(current_schema)}.steadytext_extract_facts($1, 3) as facts", ["text"])
     result = plpy.execute(plan, [value])
 
     if result and result[0]["facts"]:
@@ -919,9 +935,9 @@ AS $c$
     # Deduplicate facts if too many
     # AIDEV-NOTE: Threshold of 20 may need tuning based on usage patterns
     if len(combined_facts) > 20:
-        # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
+        # AIDEV-NOTE: Get schema dynamically at runtime for TimescaleDB continuous aggregates compatibility
         plan = plpy.prepare(
-            "SELECT @extschema@.steadytext_deduplicate_facts($1::jsonb) as deduped",
+            f"SELECT {plpy.quote_ident(current_schema)}.steadytext_deduplicate_facts($1::jsonb) as deduped",
             ["jsonb"]
         )
         result = plpy.execute(plan, [json.dumps(combined_facts)])
@@ -1042,9 +1058,9 @@ AS $c$
 
     # Generate summary using steadytext with model and unsafe_mode support
     # AIDEV-NOTE: Pass model and unsafe_mode from metadata to support remote models
-    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
+    # AIDEV-NOTE: Get schema dynamically at runtime for TimescaleDB continuous aggregates compatibility
     plan = plpy.prepare(
-        "SELECT @extschema@.steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
+        f"SELECT {plpy.quote_ident(current_schema)}.steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
         ["text", "text", "boolean"]
     )
     result = plpy.execute(plan, [prompt, model, unsafe_mode])

--- a/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
@@ -846,7 +846,8 @@ AS $c$
         return json.dumps(state_data)
 
     # Extract facts from the value
-    plan = plpy.prepare("SELECT steadytext_extract_facts($1, 3) as facts", ["text"])
+    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
+    plan = plpy.prepare("SELECT @extschema@.steadytext_extract_facts($1, 3) as facts", ["text"])
     result = plpy.execute(plan, [value])
 
     if result and result[0]["facts"]:
@@ -918,8 +919,9 @@ AS $c$
     # Deduplicate facts if too many
     # AIDEV-NOTE: Threshold of 20 may need tuning based on usage patterns
     if len(combined_facts) > 20:
+        # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
         plan = plpy.prepare(
-            "SELECT steadytext_deduplicate_facts($1::jsonb) as deduped",
+            "SELECT @extschema@.steadytext_deduplicate_facts($1::jsonb) as deduped",
             ["jsonb"]
         )
         result = plpy.execute(plan, [json.dumps(combined_facts)])
@@ -1040,8 +1042,9 @@ AS $c$
 
     # Generate summary using steadytext with model and unsafe_mode support
     # AIDEV-NOTE: Pass model and unsafe_mode from metadata to support remote models
+    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
     plan = plpy.prepare(
-        "SELECT steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
+        "SELECT @extschema@.steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
         ["text", "text", "boolean"]
     )
     result = plpy.execute(plan, [prompt, model, unsafe_mode])

--- a/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
@@ -42,9 +42,9 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration - FIXED: Get schema dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens, using the provided value or fetching the default
 resolved_max_tokens = max_tokens
@@ -270,10 +270,10 @@ if use_cache:
         return cache_result[0]["embedding"]
 
 # Cache miss - generate new embedding - FIXED: Use schema-qualified table name
-# Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 host_rv = plpy.execute(plan, ["daemon_host"])
 port_rv = plpy.execute(plan, ["daemon_port"])
@@ -444,9 +444,9 @@ import time
 try:
     # Get configuration - FIXED: Use schema-qualified table name
     # Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
     
     # Use provided values or defaults from config
     if host is None:
@@ -561,10 +561,10 @@ if use_cache:
         return cache_result[0]["score"]
 
 # Cache miss - compute new score - FIXED: Use schema-qualified table name
-# Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 host_rv = plpy.execute(plan, ["daemon_host"])
 port_rv = plpy.execute(plan, ["daemon_port"])

--- a/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql
@@ -127,7 +127,7 @@ try:
             VALUES ($1, $2)
             ON CONFLICT (cache_key) DO UPDATE
             SET response = EXCLUDED.response,
-                access_count = @extschema@.steadytext_cache.access_count + 1,
+                access_count = steadytext_cache.access_count + 1,
                 last_accessed = NOW()
         """, ["text", "text"])
         plpy.execute(insert_plan, [cache_key, result])
@@ -158,7 +158,7 @@ except Exception as e:
                     VALUES ($1, $2)
                     ON CONFLICT (cache_key) DO UPDATE
                     SET response = EXCLUDED.response,
-                        access_count = @extschema@.steadytext_cache.access_count + 1,
+                        access_count = steadytext_cache.access_count + 1,
                         last_accessed = NOW()
                 """, ["text", "text"])
                 plpy.execute(insert_plan, [cache_key, result])
@@ -193,7 +193,7 @@ except Exception as e:
                     VALUES ($1, $2)
                     ON CONFLICT (cache_key) DO UPDATE
                     SET response = EXCLUDED.response,
-                        access_count = @extschema@.steadytext_cache.access_count + 1,
+                        access_count = steadytext_cache.access_count + 1,
                         last_accessed = NOW()
                 """, ["text", "text"])
                 plpy.execute(insert_plan, [cache_key, result])

--- a/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
@@ -960,7 +960,7 @@ BEGIN
         v_current_size_mb := v_current_size_mb - v_batch_freed_mb;
         
         -- Log eviction batch
-        INSERT INTO steadytext_audit_log (action, details)
+        INSERT INTO @extschema@.steadytext_audit_log (action, details)
         VALUES (
             'cache_eviction',
             jsonb_build_object(

--- a/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
@@ -409,7 +409,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+# Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens, using the provided value or fetching the default
 resolved_max_tokens = max_tokens
@@ -451,10 +454,10 @@ if use_cache:
         cache_key = f"{prompt}::EOS::{eos_string}"
 
     # Try to get from cache first
-    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
-    cache_plan = plpy.prepare("""
+    # AIDEV-NOTE: Get schema dynamically at runtime for TimescaleDB continuous aggregates compatibility
+    cache_plan = plpy.prepare(f"""
         SELECT response 
-        FROM @extschema@.steadytext_cache 
+        FROM {plpy.quote_ident(current_schema)}.steadytext_cache 
         WHERE cache_key = $1
     """, ["text"])
     
@@ -615,9 +618,9 @@ if use_cache:
     cache_key = hashlib.sha256(cache_key_input.encode()).hexdigest()
     
     # Try to get from cache (read-only for IMMUTABLE)
-    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
+    # AIDEV-NOTE: Get schema dynamically at runtime for TimescaleDB continuous aggregates compatibility
     plan = plpy.prepare(
-        "SELECT embedding FROM @extschema@.steadytext_cache WHERE cache_key = $1",
+        f"SELECT embedding FROM {plpy.quote_ident(current_schema)}.steadytext_cache WHERE cache_key = $1",
         ["text"]
     )
     rv = plpy.execute(plan, [cache_key])
@@ -701,7 +704,10 @@ import json
 
 try:
     # Get daemon configuration
-    plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
     host_rv = plpy.execute(plan, ["daemon_host"])
     port_rv = plpy.execute(plan, ["daemon_port"])
 
@@ -715,8 +721,8 @@ try:
 
         if result.returncode == 0:
             # Update health status
-            health_plan = plpy.prepare("""
-                UPDATE @extschema@.steadytext_daemon_health
+            health_plan = plpy.prepare(f"""
+                UPDATE {plpy.quote_ident(current_schema)}.steadytext_daemon_health
                 SET status = 'healthy',
                     last_heartbeat = NOW()
                 WHERE daemon_id = 'default'
@@ -765,7 +771,10 @@ try:
         plpy.error("daemon_connector module not loaded")
 
     # Get configuration
-    plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
     host_rv = plpy.execute(plan, ["daemon_host"])
     port_rv = plpy.execute(plan, ["daemon_port"])
 
@@ -786,8 +795,11 @@ try:
         status = 'unhealthy'
 
     # Update and return health status
-    update_plan = plpy.prepare("""
-        UPDATE @extschema@.steadytext_daemon_health
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    update_plan = plpy.prepare(f"""
+        UPDATE {plpy.quote_ident(current_schema)}.steadytext_daemon_health
         SET status = $1,
             last_heartbeat = CASE WHEN $1 = 'healthy' THEN NOW() ELSE last_heartbeat END
         WHERE daemon_id = 'default'
@@ -825,8 +837,8 @@ try:
 
     if result.returncode == 0:
         # Update health status
-        health_plan = plpy.prepare("""
-            UPDATE @extschema@.steadytext_daemon_health
+        health_plan = plpy.prepare(f"""
+            UPDATE {plpy.quote_ident(current_schema)}.steadytext_daemon_health
             SET status = 'stopping',
                 last_heartbeat = NOW()
             WHERE daemon_id = 'default'
@@ -1173,7 +1185,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+# Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens
 resolved_max_tokens = max_tokens
@@ -1335,7 +1350,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+# Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens
 resolved_max_tokens = max_tokens
@@ -1488,7 +1506,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-plan = plpy.prepare("SELECT value FROM @extschema@.steadytext_config WHERE key = $1", ["text"])
+# Get the schema of this function dynamically at runtime
+schema_result = plpy.execute("SELECT current_schema()")
+current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens
 resolved_max_tokens = max_tokens
@@ -1678,8 +1699,12 @@ AS $c$
     # AIDEV-NOTE: Consider batching embedding generation for better performance
     embeddings = []
     for text in fact_texts:
-        # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
-        plan = plpy.prepare("SELECT @extschema@.steadytext_embed($1) as embedding", ["text"])
+        # AIDEV-NOTE: Get schema dynamically at runtime for TimescaleDB continuous aggregates compatibility
+        # Get the schema once outside the loop for efficiency
+        if not 'current_schema' in locals():
+            schema_result = plpy.execute("SELECT current_schema()")
+            current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+        plan = plpy.prepare(f"SELECT {plpy.quote_ident(current_schema)}.steadytext_embed($1) as embedding", ["text"])
         result = plpy.execute(plan, [text])
         if result and result[0]["embedding"]:
             embeddings.append(np.array(result[0]["embedding"]))
@@ -1748,8 +1773,10 @@ AS $c$
         return json.dumps(state_data)
 
     # Extract facts from the value
-    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
-    plan = plpy.prepare("SELECT @extschema@.steadytext_extract_facts($1, 3) as facts", ["text"])
+    # AIDEV-NOTE: Get schema dynamically at runtime for TimescaleDB continuous aggregates compatibility
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT {plpy.quote_ident(current_schema)}.steadytext_extract_facts($1, 3) as facts", ["text"])
     result = plpy.execute(plan, [value])
 
     if result and result[0]["facts"]:

--- a/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
@@ -94,7 +94,7 @@ CREATE TABLE steadytext_config (
 );
 
 -- Insert default configuration
-INSERT INTO steadytext_config (key, value, description) VALUES
+INSERT INTO @extschema@.steadytext_config (key, value, description) VALUES
     ('daemon_host', '"localhost"', 'SteadyText daemon host'),
     ('daemon_port', '5555', 'SteadyText daemon port'),
     ('cache_enabled', 'true', 'Enable caching'),
@@ -165,7 +165,7 @@ CREATE OR REPLACE VIEW steadytext_cache_with_frecency AS
 SELECT *,
     -- Calculate frecency score dynamically
     access_count * exp(-extract(epoch from (NOW() - last_accessed)) / 86400.0) AS frecency_score
-FROM steadytext_cache;
+FROM @extschema@.steadytext_cache;
 
 -- AIDEV-NOTE: This view replaces the GENERATED column which couldn't use NOW()
 -- The frecency score decays exponentially based on time since last access
@@ -451,9 +451,10 @@ if use_cache:
         cache_key = f"{prompt}::EOS::{eos_string}"
 
     # Try to get from cache first
+    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
     cache_plan = plpy.prepare("""
         SELECT response 
-        FROM steadytext_cache 
+        FROM @extschema@.steadytext_cache 
         WHERE cache_key = $1
     """, ["text"])
     
@@ -614,8 +615,9 @@ if use_cache:
     cache_key = hashlib.sha256(cache_key_input.encode()).hexdigest()
     
     # Try to get from cache (read-only for IMMUTABLE)
+    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
     plan = plpy.prepare(
-        "SELECT embedding FROM steadytext_cache WHERE cache_key = $1",
+        "SELECT embedding FROM @extschema@.steadytext_cache WHERE cache_key = $1",
         ["text"]
     )
     rv = plpy.execute(plan, [cache_key])
@@ -714,7 +716,7 @@ try:
         if result.returncode == 0:
             # Update health status
             health_plan = plpy.prepare("""
-                UPDATE steadytext_daemon_health
+                UPDATE @extschema@.steadytext_daemon_health
                 SET status = 'healthy',
                     last_heartbeat = NOW()
                 WHERE daemon_id = 'default'
@@ -785,7 +787,7 @@ try:
 
     # Update and return health status
     update_plan = plpy.prepare("""
-        UPDATE steadytext_daemon_health
+        UPDATE @extschema@.steadytext_daemon_health
         SET status = $1,
             last_heartbeat = CASE WHEN $1 = 'healthy' THEN NOW() ELSE last_heartbeat END
         WHERE daemon_id = 'default'
@@ -824,7 +826,7 @@ try:
     if result.returncode == 0:
         # Update health status
         health_plan = plpy.prepare("""
-            UPDATE steadytext_daemon_health
+            UPDATE @extschema@.steadytext_daemon_health
             SET status = 'stopping',
                 last_heartbeat = NOW()
             WHERE daemon_id = 'default'
@@ -862,7 +864,7 @@ AS $c$
         COALESCE(AVG(access_count), 0)::FLOAT as avg_access_count,
         MIN(created_at) as oldest_entry,
         MAX(created_at) as newest_entry
-    FROM steadytext_cache;
+    FROM @extschema@.steadytext_cache;
 $c$;
 
 -- Clear cache
@@ -871,7 +873,7 @@ RETURNS BIGINT
 LANGUAGE sql
 AS $c$
     WITH deleted AS (
-        DELETE FROM steadytext_cache
+        DELETE FROM @extschema@.steadytext_cache
         RETURNING *
     )
     SELECT COUNT(*) FROM deleted;
@@ -909,19 +911,19 @@ BEGIN
         COUNT(*),
         COALESCE(SUM(pg_column_size(response) + pg_column_size(embedding)) / 1024.0 / 1024.0, 0)
     INTO v_current_entries, v_current_size_mb
-    FROM steadytext_cache;
+    FROM @extschema@.steadytext_cache;
     
     -- Set default targets if not provided
     IF target_entries IS NULL THEN
         SELECT value::INT INTO target_entries 
-        FROM steadytext_config 
+        FROM @extschema@.steadytext_config 
         WHERE key = 'cache_max_entries';
         target_entries := COALESCE(target_entries, 10000);
     END IF;
     
     IF target_size_mb IS NULL THEN
         SELECT value::FLOAT INTO target_size_mb 
-        FROM steadytext_config 
+        FROM @extschema@.steadytext_config 
         WHERE key = 'cache_max_size_mb';
         target_size_mb := COALESCE(target_size_mb, 1000);
     END IF;
@@ -930,10 +932,10 @@ BEGIN
     WHILE (v_current_entries > target_entries OR v_current_size_mb > target_size_mb) LOOP
         -- Delete oldest entries (FIFO eviction)
         WITH deleted AS (
-            DELETE FROM steadytext_cache
+            DELETE FROM @extschema@.steadytext_cache
             WHERE id IN (
                 SELECT id 
-                FROM steadytext_cache
+                FROM @extschema@.steadytext_cache
                 WHERE created_at < NOW() - INTERVAL '1 hour' * min_age_hours
                 ORDER BY created_at ASC  -- Oldest first
                 LIMIT batch_size
@@ -991,7 +993,7 @@ DECLARE
 BEGIN
     -- Check if eviction is enabled
     SELECT value::BOOLEAN INTO v_enabled 
-    FROM steadytext_config 
+    FROM @extschema@.steadytext_config 
     WHERE key = 'cache_eviction_enabled';
     
     IF NOT COALESCE(v_enabled, TRUE) THEN
@@ -1034,7 +1036,7 @@ AS $c$
         created_at,
         EXTRACT(EPOCH FROM (NOW() - created_at)) / 86400.0 as age_days,
         pg_column_size(response) + pg_column_size(embedding) as size_bytes
-    FROM steadytext_cache
+    FROM @extschema@.steadytext_cache
     WHERE created_at < NOW() - INTERVAL '1 hour'  -- Respect min age
     ORDER BY created_at ASC  -- Oldest first
     LIMIT preview_count;
@@ -1064,12 +1066,12 @@ AS $c$
             COUNT(*) as entry_count,
             AVG(access_count) as avg_access_count,
             SUM(pg_column_size(response) + pg_column_size(embedding)) / 1024.0 / 1024.0 as total_size_mb
-        FROM steadytext_cache
+        FROM @extschema@.steadytext_cache
         GROUP BY 1
     ),
     total AS (
         SELECT COUNT(*) as total_entries
-        FROM steadytext_cache
+        FROM @extschema@.steadytext_cache
     )
     SELECT 
         cb.age_bucket,
@@ -1095,7 +1097,7 @@ CREATE OR REPLACE VIEW steadytext_cache_with_frecency AS
 SELECT *,
     -- Simple age-based score for compatibility (higher = older = more likely to evict)
     EXTRACT(EPOCH FROM (NOW() - created_at)) / 86400.0 AS frecency_score
-FROM steadytext_cache;
+FROM @extschema@.steadytext_cache;
 
 COMMENT ON VIEW steadytext_cache_with_frecency IS 
 'Compatibility view - frecency_score now represents age in days (v1.4.1+)';
@@ -1118,7 +1120,7 @@ RETURNS TEXT
 LANGUAGE sql
 STABLE PARALLEL SAFE LEAKPROOF
 AS $c$
-    SELECT value::text FROM steadytext_config WHERE key = config_key;
+    SELECT value::text FROM @extschema@.steadytext_config WHERE key = config_key;
 $c$;
 
 -- AIDEV-SECTION: STRUCTURED_GENERATION_FUNCTIONS
@@ -1676,7 +1678,8 @@ AS $c$
     # AIDEV-NOTE: Consider batching embedding generation for better performance
     embeddings = []
     for text in fact_texts:
-        plan = plpy.prepare("SELECT steadytext_embed($1) as embedding", ["text"])
+        # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
+        plan = plpy.prepare("SELECT @extschema@.steadytext_embed($1) as embedding", ["text"])
         result = plpy.execute(plan, [text])
         if result and result[0]["embedding"]:
             embeddings.append(np.array(result[0]["embedding"]))
@@ -1745,7 +1748,8 @@ AS $c$
         return json.dumps(state_data)
 
     # Extract facts from the value
-    plan = plpy.prepare("SELECT steadytext_extract_facts($1, 3) as facts", ["text"])
+    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
+    plan = plpy.prepare("SELECT @extschema@.steadytext_extract_facts($1, 3) as facts", ["text"])
     result = plpy.execute(plan, [value])
 
     if result and result[0]["facts"]:
@@ -1818,7 +1822,7 @@ AS $c$
     # AIDEV-NOTE: Threshold of 20 may need tuning based on usage patterns
     if len(combined_facts) > 20:
         plan = plpy.prepare(
-            "SELECT steadytext_deduplicate_facts($1::jsonb) as deduped",
+            "SELECT @extschema@.steadytext_deduplicate_facts($1::jsonb) as deduped",
             ["jsonb"]
         )
         result = plpy.execute(plan, [json.dumps(combined_facts)])
@@ -1939,8 +1943,9 @@ AS $c$
 
     # Generate summary using steadytext with model and unsafe_mode support
     # AIDEV-NOTE: Pass model and unsafe_mode from metadata to support remote models
+    # AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
     plan = plpy.prepare(
-        "SELECT steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
+        "SELECT @extschema@.steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
         ["text", "text", "boolean"]
     )
     result = plpy.execute(plan, [prompt, model, unsafe_mode])
@@ -2035,8 +2040,9 @@ if ':' in model and not unsafe_mode:
 # Use steadytext_generate for actual summarization
 prompt = f"Summarize the following text in 1-2 sentences: {input_text[:500]}"
 
+# AIDEV-NOTE: Use @extschema@ for schema qualification to work with TimescaleDB continuous aggregates
 plan = plpy.prepare(
-    "SELECT steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
+    "SELECT @extschema@.steadytext_generate($1, NULL, true, 42, '[EOS]', $2, NULL, NULL, NULL, $3) as summary",
     ["text", "text", "boolean"]
 )
 result = plpy.execute(plan, [prompt, model, unsafe_mode])
@@ -2199,7 +2205,7 @@ BEGIN
     request_id := gen_random_uuid();
     
     -- Insert into queue
-    INSERT INTO steadytext_queue (
+    INSERT INTO @extschema@.steadytext_queue (
         request_id,
         request_type,
         prompt,
@@ -2251,7 +2257,7 @@ AS $c$
     
     # Insert into queue
     plpy.execute("""
-        INSERT INTO steadytext_queue 
+        INSERT INTO @extschema@.steadytext_queue 
         (request_id, request_type, params, status, created_at, priority)
         VALUES ($1, 'rerank', $2::jsonb, 'pending', CURRENT_TIMESTAMP, 5)
     """, [request_id, json.dumps(params)])
@@ -2363,7 +2369,7 @@ AS $c$
         }
         
         plpy.execute("""
-            INSERT INTO steadytext_queue 
+            INSERT INTO @extschema@.steadytext_queue 
             (request_id, request_type, params, status, created_at, priority)
             VALUES ($1, 'batch_rerank', $2::jsonb, 'pending', CURRENT_TIMESTAMP, 5)
         """, [request_id, json.dumps(params)])
@@ -2396,7 +2402,7 @@ VOLATILE PARALLEL SAFE STRICT
 AS $$
 BEGIN
     -- Update or insert configuration value
-    INSERT INTO steadytext_config (key, value, description, updated_at, updated_by)
+    INSERT INTO @extschema@.steadytext_config (key, value, description, updated_at, updated_by)
     VALUES (config_key, to_jsonb(config_value), NULL, NOW(), current_user)
     ON CONFLICT (key) DO UPDATE
     SET value = to_jsonb(config_value),
@@ -2414,7 +2420,7 @@ RETURNS TEXT
 LANGUAGE sql
 STABLE PARALLEL SAFE STRICT
 AS $$
-    SELECT value #>> '{}' FROM steadytext_config WHERE key = config_key;
+    SELECT value #>> '{}' FROM @extschema@.steadytext_config WHERE key = config_key;
 $$;
 
 -- AIDEV-SECTION: ASYNC_RESULT_RETRIEVAL
@@ -2450,8 +2456,8 @@ AS $$
         completed_at,
         processing_time_ms,
         request_type
-    FROM steadytext_queue
-    WHERE steadytext_queue.request_id = steadytext_check_async.request_id;
+    FROM @extschema@.steadytext_queue
+    WHERE @extschema@.steadytext_queue.request_id = steadytext_check_async.request_id;
 $$;
 
 -- Convenience function to get result directly (blocks until ready or timeout)
@@ -2511,10 +2517,10 @@ DECLARE
 BEGIN
     -- AIDEV-NOTE: Cancel a pending async request
     
-    UPDATE steadytext_queue
+    UPDATE @extschema@.steadytext_queue
     SET status = 'cancelled',
         completed_at = NOW()
-    WHERE steadytext_queue.request_id = steadytext_cancel_async.request_id
+    WHERE @extschema@.steadytext_queue.request_id = steadytext_cancel_async.request_id
     AND status IN ('pending', 'processing');
     
     GET DIAGNOSTICS rows_updated = ROW_COUNT;
@@ -2545,7 +2551,7 @@ BEGIN
     -- Create a request for each text
     FOR i IN 1..array_length(texts, 1) LOOP
         -- Insert into queue
-        INSERT INTO steadytext_queue (
+        INSERT INTO @extschema@.steadytext_queue (
             request_type,
             prompt
         ) VALUES (
@@ -2584,7 +2590,7 @@ AS $$
         result,
         error,
         completed_at
-    FROM steadytext_queue
+    FROM @extschema@.steadytext_queue
     WHERE request_id = ANY(request_ids)
     ORDER BY array_position(request_ids, request_id);
 $$;
@@ -2619,13 +2625,14 @@ BEGIN
         v_cache_key := prompt;
         
         -- Check if already cached
-        PERFORM 1 FROM steadytext_cache WHERE cache_key = v_cache_key;
+        -- AIDEV-NOTE: Use schema qualification for TimescaleDB continuous aggregates
+        PERFORM 1 FROM @extschema@.steadytext_cache WHERE cache_key = v_cache_key;
         
         IF NOT FOUND THEN
             -- Resolve max_tokens default
             IF max_tokens IS NULL THEN
                 SELECT value::INT INTO max_tokens 
-                FROM steadytext_config 
+                FROM @extschema@.steadytext_config 
                 WHERE key = 'default_max_tokens';
                 max_tokens := COALESCE(max_tokens, 512);
             END IF;
@@ -2683,7 +2690,8 @@ BEGIN
         v_cache_key := encode(digest(v_cache_key_input, 'sha256'), 'hex');
         
         -- Check if already cached
-        PERFORM 1 FROM steadytext_cache WHERE cache_key = v_cache_key;
+        -- AIDEV-NOTE: Use schema qualification for TimescaleDB continuous aggregates
+        PERFORM 1 FROM @extschema@.steadytext_cache WHERE cache_key = v_cache_key;
         
         IF NOT FOUND THEN
             -- Store in cache
@@ -2739,7 +2747,7 @@ BEGIN
             params_json := params_json || jsonb_build_object('unsafe_mode', unsafe_mode);
         END IF;
         
-        INSERT INTO steadytext_queue (
+        INSERT INTO @extschema@.steadytext_queue (
             request_id,
             request_type,
             params,

--- a/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
+++ b/pg_steadytext/sql/pg_steadytext--2025.8.17.sql
@@ -409,10 +409,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-# Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens, using the provided value or fetching the default
 resolved_max_tokens = max_tokens
@@ -1185,10 +1185,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-# Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens
 resolved_max_tokens = max_tokens
@@ -1350,10 +1350,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-# Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens
 resolved_max_tokens = max_tokens
@@ -1506,10 +1506,10 @@ if not daemon_connector:
     plpy.error("daemon_connector module not loaded")
 
 # Get configuration
-# Get the schema of this function dynamically at runtime
-schema_result = plpy.execute("SELECT current_schema()")
-current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
-plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
+    # Get the schema of this function dynamically at runtime
+    schema_result = plpy.execute("SELECT current_schema()")
+    current_schema = schema_result[0]['current_schema'] if schema_result else 'public'
+    plan = plpy.prepare(f"SELECT value FROM {plpy.quote_ident(current_schema)}.steadytext_config WHERE key = $1", ["text"])
 
 # Resolve max_tokens
 resolved_max_tokens = max_tokens


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add schema qualification to all table and function references

- Fix TimescaleDB continuous aggregates compatibility issues

- Replace unqualified references with @extschema@ prefix

- Update SQL migration and main schema files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Unqualified References"] --> B["@extschema@ Qualification"]
  B --> C["TimescaleDB Compatible"]
  D["Function Calls"] --> B
  E["Table References"] --> B
  F["View References"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pg_steadytext--2025.8.16--2025.8.17.sql</strong><dd><code>Schema qualify function calls in migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pg_steadytext/sql/pg_steadytext--2025.8.16--2025.8.17.sql

<ul><li>Add @extschema@ prefix to <code>steadytext_extract_facts</code> function calls<br> <li> Add @extschema@ prefix to <code>steadytext_deduplicate_facts</code> function calls  <br> <li> Add @extschema@ prefix to <code>steadytext_generate</code> function calls<br> <li> Include AIDEV-NOTE comments explaining TimescaleDB compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/101/files#diff-7fd3daebd2e2d935f122c65e7cd6d7f6a93aac90bd54917cf5237cc885c35b55">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pg_steadytext--2025.8.17.sql</strong><dd><code>Schema qualify all table and function references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pg_steadytext/sql/pg_steadytext--2025.8.17.sql

<ul><li>Add @extschema@ prefix to all <code>steadytext_config</code> table references<br> <li> Add @extschema@ prefix to all <code>steadytext_cache</code> table references<br> <li> Add @extschema@ prefix to all <code>steadytext_daemon_health</code> table <br>references<br> <li> Add @extschema@ prefix to all <code>steadytext_queue</code> table references<br> <li> Add @extschema@ prefix to function calls in plpy.prepare statements<br> <li> Update view definitions to use schema-qualified table names</ul>


</details>


  </td>
  <td><a href="https://github.com/julep-ai/steadytext/pull/101/files#diff-5685ad1abbe4537d21fa749671c119e77e72ed194ee67c1fed3000ebffcc3fe9">+48/-40</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add schema qualification to SQL references in `pg_steadytext` files for TimescaleDB compatibility.
> 
>   - **Schema Qualification**:
>     - Add `@extschema@` prefix to all table and function references in `pg_steadytext--2025.8.16--2025.8.17.sql` and `pg_steadytext--2025.8.17.sql`.
>     - Ensure compatibility with TimescaleDB continuous aggregates by dynamically determining schema at runtime.
>   - **File Updates**:
>     - Update `pg_steadytext--2025.8.16--2025.8.17.sql` to include schema qualification for functions like `steadytext_extract_facts`, `steadytext_deduplicate_facts`, and `steadytext_generate`.
>     - Update `pg_steadytext--2025.8.17.sql` to reflect schema-qualified table names in view definitions and other SQL statements.
>   - **Miscellaneous**:
>     - Include AIDEV-NOTE comments explaining TimescaleDB compatibility.
>     - Replace unqualified references with `@extschema@` prefix for better schema management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=julep-ai%2Fsteadytext&utm_source=github&utm_medium=referral)<sup> for 0bac59b39b4ed3aa69cc71ab411c8ab41b12223a. You can [customize](https://app.ellipsis.dev/julep-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->